### PR TITLE
(feat): adds a topology document and base identity protocol specification

### DIFF
--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -54,7 +54,7 @@ be resolvable as a `Web DID`.
 
 # 4. Self-Issued ID Tokens
 
-A Self-iIssued ID Token is defined in
+A Self-Issued ID Token is defined in
 the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#section-1.1) :
 
 > In the Self-Issued OP case, the ID Token is self-signed with a private key under the user's control, identified by the

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -106,6 +106,6 @@ an [OAuth 2.0 Client Credential Grant](https://www.rfc-editor.org/rfc/rfc6749.ht
 Service (STS) Endpoint. How the participant agent obtains the endpoint address is participant-specific and beyond the
 scope of this specification.
 
-The Self-iIssued ID Token request MAY contain the `bearer_access_scope` authorization request parameter which is set to a
+The Self-Issued ID Token request MAY contain the `bearer_access_scope` authorization request parameter which is set to a
 list of space-delimited scopes the response `VP Access Token` set in the `access_token` claim will be enabled for. If
 no `bearer_access_scope` parameter is present, the `access_token` claim MUST not be included.

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -73,7 +73,7 @@ include the following claims:
 - The `iss` and `sub` claims MUST be equal and set to the bearer's (participant's) web DID.
 - The `sub_jwk` claim is not used
 - The `aud` set to the `participant_id` of the relying party (RP)
-- The `client_id` set to the `participant id` of the consumer
+- The `client_id` set to the `participant_id` of the consumer
 - The `jti` claim that is used to mitigate against replay attacks
 - All VPs in the `vp` claim MUST be in the format specified by
   the [Verifiable Credentials Data Model v1.1](https://www.w3.org/TR/vc-data-model/)

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -1,0 +1,111 @@
+# 1. Introduction
+
+This document defines a base protocol for communicating participant identities and claims in a Tractus-X dataspace. This
+specification assumes familiarity with the [Tractus-X Dataspace Topology Specification](tx.dataspace.topology.md).
+
+# 2. Motivation
+
+The key goal of this protocol specification is to minimize the risk of business disruption related to the failure of
+identity and credential systems in a Tractus-X dataspace. As such, it provides a design for a decentralized system to
+communicate participant identities and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) (VCs).
+
+> Note that it is not a design goal of this protocol to support a self-sovereign data exchange network where each
+> participant is in full control of its ability to operate on the network. Specifically, participants do not perform
+> self-registration, and instead rely on a _**Registration Service**_. Imposing this restriction provides a mechanism
+> for business security (the field of participants can be restricted through a verification process) and greatly
+> simplifies the technical problem at hand.
+
+## 2.1. Decentralization
+
+Decentralization is achieved in the following ways:
+
+- **Self-Issued Identity Tokens** - Each participant is responsible for creating and cryptographically signing its own
+  identity tokens. A central identity provider is therefore not required, eliminating a potential locus of network
+  failure.
+- **Participant VC and Cryptographic Material Management** - Each participant is responsible for storing VCs and
+  presenting them (VPs) in the network. Each participant is also responsible for storing and making its own
+  cryptographic material available to verifiers in the network. This specification defines how VCs are presented and
+  verified without the need for a third-party verification service.
+- **Multiple Trust Anchors** - Participant VCs are signed by a third-party issuer acting as a trust anchor using a
+  cryptographic proof. The identity protocol allows for multiple trust anchors in a dataspace.
+
+# 3. Identities and Identifiers
+
+Each participant MUST have a unique, immutable **_identity_** provided by the `Registration Service` and
+a [Web DID](https://w3c-ccg.github.io/did-method-web/) that it chooses. This relationship is expressed as:
+
+```
+ID  ------ Can resolve to -----> DID
+ ^                                |
+ |                                |
+ |----------Associated with--------                               
+```
+
+This immutable identity is termed the `participant id`.
+
+## 3.1.The Membership VC
+
+Dataspaces which implement the TX identity protocol MUST define a VC that adheres to
+the [Verifiable Credentials Data Model v1.1](https://www.w3.org/TR/vc-data-model/) and cryptographically binds the
+`participant id` to its `Web DID`. This VC is termed the `Membership VC`. The VC verifier's cryptographic material MUST
+be resolvable as a `Web DID`.
+
+> TODO: do we want to define the subject material of the Membership VC or should we leave it dataspace specific?
+
+# 4. Self-Issued Tokens
+
+A self-issued token is defined in
+the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#section-1.1) :
+
+> In the Self-Issued OP case, the ID Token is self-signed with a private key under the user's control, identified by the
+> sub-claim.
+
+A client may obtain a self-issued token using a variety or OAuth grant types. If the OAuth 2.0 Client Credential Grant
+type is used, the client MUST conform
+to [Section 6](#6-using-the-oauth-2-client-credential-grant-to-obtain-access-tokens-from-an-sts).
+
+# 4.1. Self-Issued Token Contents
+
+The self-issued token MUST adhere
+to [JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068) and MUST
+include the following claims:
+
+- The `iss` and `sub` claims MUST be equal and set to the bearer's (participant's) web DID.
+- The `sub_jwk` claim is not used
+- The `aud` set to the `participant id` of the relying party (RP)
+- The `client_id` set to the `participant id` of the consumer
+- The `jti` claim that is used to mitigate against replay attacks
+- All VPs in the `vp` claim MUST be in the format specified by
+  the [Verifiable Credentials Data Model v1.1](https://www.w3.org/TR/vc-data-model/)
+
+> Note implementations should consider HTTP header restriction sizes when including a `vp` claim. If the claim size
+> exceeds 3-4K, a separate protocol should be used that allows the RP to resolve VPs out-of-band.
+
+## 4.1.1. VP Access Token
+
+A Self-Issued token MAY contain an access token as an `access_token` claim that can be used by the relying party to
+obtain additional VPs.
+
+> TODO: determine claim name
+
+# 4.2. Validating Self-Issued Tokens
+
+The relying party MUST follow the steps specified in
+the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#section-11.1).
+
+# 5. Verifiable Presentations
+
+Additional client metadata such as Verifiable Presentations can be obtained by a relying party (RP) using the
+client's `DID`, typically specified in the `sub` claim of a self-issued token. The DID document may contain `service`
+entries that can be used to resolve metadata.
+
+# 6. Using the OAuth 2 Client Credential Grant to Obtain Access Tokens from an STS
+
+A self-issued token MAY be obtained by a participant agent executing
+an [OAuth 2.0 Client Credential Grant](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.4) against a Secure Token
+Service (STS) Endpoint. How the participant agent obtains the endpoint address is participant-specific and beyond the
+scope of this specification.
+
+The self-issued token request MAY contain the `bearer_access_scope` authorization request parameter which is set to a
+list of space-delimited scopes the response `VP Access Token` set in the `access_token` claim will be enabled for. If
+no `bearer_access_scope` parameter is present, the `access_token` claim MUST not be included.

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -101,7 +101,7 @@ entries that can be used to resolve metadata.
 
 # 6. Using the OAuth 2 Client Credential Grant to Obtain Access Tokens from an STS
 
-A Self-iIssued ID Token MAY be obtained by a participant agent executing
+A Self-Issued ID Token MAY be obtained by a participant agent executing
 an [OAuth 2.0 Client Credential Grant](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.4) against a Secure Token
 Service (STS) Endpoint. How the participant agent obtains the endpoint address is participant-specific and beyond the
 scope of this specification.

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -64,7 +64,7 @@ A client may obtain a Self-Issued ID Token using a variety or OAuth grant types.
 type is used, the client MUST conform
 to [Section 6](#6-using-the-oauth-2-client-credential-grant-to-obtain-access-tokens-from-an-sts).
 
-# 4.1. Self-iIssued ID Token Contents
+# 4.1. Self-Issued ID Token Contents
 
 The Self-iIssued ID Token MUST adhere
 to [JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068) and MUST

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -60,7 +60,7 @@ the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/open
 > In the Self-Issued OP case, the ID Token is self-signed with a private key under the user's control, identified by the
 > sub-claim.
 
-A client may obtain a Self-iIssued ID Token using a variety or OAuth grant types. If the OAuth 2.0 Client Credential Grant
+A client may obtain a Self-Issued ID Token using a variety or OAuth grant types. If the OAuth 2.0 Client Credential Grant
 type is used, the client MUST conform
 to [Section 6](#6-using-the-oauth-2-client-credential-grant-to-obtain-access-tokens-from-an-sts).
 

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -52,21 +52,21 @@ be resolvable as a `Web DID`.
 
 > TODO: do we want to define the subject material of the Membership VC or should we leave it dataspace specific?
 
-# 4. Self-Issued Tokens
+# 4. Self-Issued ID Tokens
 
-A self-issued token is defined in
+A Self-iIssued ID Token is defined in
 the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#section-1.1) :
 
 > In the Self-Issued OP case, the ID Token is self-signed with a private key under the user's control, identified by the
 > sub-claim.
 
-A client may obtain a self-issued token using a variety or OAuth grant types. If the OAuth 2.0 Client Credential Grant
+A client may obtain a Self-iIssued ID Token using a variety or OAuth grant types. If the OAuth 2.0 Client Credential Grant
 type is used, the client MUST conform
 to [Section 6](#6-using-the-oauth-2-client-credential-grant-to-obtain-access-tokens-from-an-sts).
 
-# 4.1. Self-Issued Token Contents
+# 4.1. Self-iIssued ID Token Contents
 
-The self-issued token MUST adhere
+The Self-iIssued ID Token MUST adhere
 to [JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068) and MUST
 include the following claims:
 
@@ -83,12 +83,12 @@ include the following claims:
 
 ## 4.1.1. VP Access Token
 
-A Self-Issued token MAY contain an access token as an `access_token` claim that can be used by the relying party to
+A Self-iIssued ID Token MAY contain an access token as an `access_token` claim that can be used by the relying party to
 obtain additional VPs.
 
 > TODO: determine claim name
 
-# 4.2. Validating Self-Issued Tokens
+# 4.2. Validating Self-Issued ID Tokens
 
 The relying party MUST follow the steps specified in
 the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#section-11.1).
@@ -96,16 +96,16 @@ the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/open
 # 5. Verifiable Presentations
 
 Additional client metadata such as Verifiable Presentations can be obtained by a relying party (RP) using the
-client's `DID`, typically specified in the `sub` claim of a self-issued token. The DID document may contain `service`
+client's `DID`, typically specified in the `sub` claim of a Self-iIssued ID Token. The DID document may contain `service`
 entries that can be used to resolve metadata.
 
 # 6. Using the OAuth 2 Client Credential Grant to Obtain Access Tokens from an STS
 
-A self-issued token MAY be obtained by a participant agent executing
+A Self-iIssued ID Token MAY be obtained by a participant agent executing
 an [OAuth 2.0 Client Credential Grant](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.4) against a Secure Token
 Service (STS) Endpoint. How the participant agent obtains the endpoint address is participant-specific and beyond the
 scope of this specification.
 
-The self-issued token request MAY contain the `bearer_access_scope` authorization request parameter which is set to a
+The Self-iIssued ID Token request MAY contain the `bearer_access_scope` authorization request parameter which is set to a
 list of space-delimited scopes the response `VP Access Token` set in the `access_token` claim will be enabled for. If
 no `bearer_access_scope` parameter is present, the `access_token` claim MUST not be included.

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -96,7 +96,7 @@ the [Self-Issued OpenID Provider v2 specification](https://openid.net/specs/open
 # 5. Verifiable Presentations
 
 Additional client metadata such as Verifiable Presentations can be obtained by a relying party (RP) using the
-client's `DID`, typically specified in the `sub` claim of a Self-iIssued ID Token. The DID document may contain `service`
+client's `DID`, typically specified in the `sub` claim of a Self-Issued ID Token. The DID document may contain `service`
 entries that can be used to resolve metadata.
 
 # 6. Using the OAuth 2 Client Credential Grant to Obtain Access Tokens from an STS

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -72,7 +72,7 @@ include the following claims:
 
 - The `iss` and `sub` claims MUST be equal and set to the bearer's (participant's) web DID.
 - The `sub_jwk` claim is not used
-- The `aud` set to the `participant id` of the relying party (RP)
+- The `aud` set to the `participant_id` of the relying party (RP)
 - The `client_id` set to the `participant id` of the consumer
 - The `jti` claim that is used to mitigate against replay attacks
 - All VPs in the `vp` claim MUST be in the format specified by

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -66,7 +66,7 @@ to [Section 6](#6-using-the-oauth-2-client-credential-grant-to-obtain-access-tok
 
 # 4.1. Self-Issued ID Token Contents
 
-The Self-iIssued ID Token MUST adhere
+The Self-Issued ID Token MUST adhere
 to [JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068) and MUST
 include the following claims:
 

--- a/specifications/M1/identity.protocol.base.md
+++ b/specifications/M1/identity.protocol.base.md
@@ -83,7 +83,7 @@ include the following claims:
 
 ## 4.1.1. VP Access Token
 
-A Self-iIssued ID Token MAY contain an access token as an `access_token` claim that can be used by the relying party to
+A Self-Issued ID Token MAY contain an access token as an `access_token` claim that can be used by the relying party to
 obtain additional VPs.
 
 > TODO: determine claim name

--- a/specifications/M1/tx.dataspace.topology.md
+++ b/specifications/M1/tx.dataspace.topology.md
@@ -1,0 +1,89 @@
+# 1. Introduction
+
+This document details the systems topology that Tractus-X dataspaces employ. This topology adheres to the model defined
+by the [Dataspace Protocol Specifications](https://docs.internationaldataspaces.org/dataspace-protocol/overview/model) (
+DSP):
+
+- The **Dataspace Authority** manages the dataspace. In a Tractus-X dataspace, this role may be federated across
+  multiple operating companies responsible for registration, onboarding, and operations management.
+- A **Participant** is a member the dataspace. In a Tractus-X dataspace, members may take on different roles, which are
+  attested to by **Verifiable Credentials**.
+- A **Participant Agent** performs tasks such as publishing a catalog or engaging in an asset transfer. Note that a
+  participant agent is a logical construct and does not necessarily correspond to a single runtime process.
+- An **Identity Provider** is a service that generates ID tokens used to verify the identity of a Participant Agent. In
+  a Tractus-X dataspace, each participant will use their own identity provider, which may be self-hosted or hosted in a
+  managed environment.
+- A **Credential Issuer** issues Verifiable Credentials (VC) used by participant agents to allow access to assets and
+  verify usage control.
+
+## 1.1. Scope
+
+This specification does not cover dataspace registration systems managed by a Dataspace Authority (operating company) as
+the participant registration and discovery process is out-of-scope.
+
+## 1.2. Identities
+
+The DSP specifications are based on the concept that all participants have a stable identifier (ID). This ID is
+typically a number assigned to the participant business entity. In this scheme, participant agent identities may be
+ephemeral since all operations such as signing `contract agreements`are associated with the participant identity.
+
+This specification will also make use of DIDs, which can be employed to cryptographically verify a participant identity.
+These are related as follows:
+
+```
+ID  ------ Can resolve to -----> DID
+ ^                                |
+ |                                |
+ |----------Associated with--------                               
+```
+
+A DID may also be used as an ID, but it is recommended to distinguish the two to allow for DID rotation. For example, a
+participant may opt to change its hosting environment, resulting in a change to its DID such as the URL associated with
+its DID in the case of `did:web` or its DID method. Since its Identifier remains stable, existing signed contracts will
+not be impacted.
+
+# 2. Systems
+
+## 2.1. Registration System
+
+The registration system is responsible for participant registration, onboarding, and management.
+
+### 2.1.1. Registration Process
+
+When a participant is onboarded, it will be assigned an ID and either a **secret token/code** or **Membership VC** that
+will allow the participant to bootstrap its systems. If provided a secret token, the participant will be able to
+exchange it for a Membership VC with a Credential Issuer.
+
+## 2.2. Participant Agent Systems
+
+Participants will run one or more agent systems that interact in the dataspace. These systems may offer data catalogs,
+perform data transfers or provide application functionality.
+
+A participant may run the following identity-related agents. Note that this is a logical description and may not
+represent an actual deployment topology.
+
+### 2.2.1 Security Token Service (STS).
+
+The STS creates self-issued authorization tokens that contain identity claims used by participant agents under the
+control of the same participant.
+
+### 2.2.2 Verifiable Credential Service (VCS)
+
+The VCS manages [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/). This includes read and write endpoints
+for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
+
+### 2.2.3 DID Service (DIDS).
+
+The DCS Creates, signs and publishes DID documents.
+
+## 2.3. Issuer Service (IS)
+
+The Issuer Service is run by trust anchor and manages the lifecycle of Verifiable Credentials in a dataspace. A
+dataspace may contain multiple Issuer Services run by different trust anchors. The Issuer Service:
+
+- Issues VCs for dataspace participants
+- Manages revocation lists for VC types it issues based
+  on [Verifiable Credentials Status List v2021](https://www.w3.org/TR/vc-status-list/).
+- Provides cryptographic material used to verify VPs and VCs. If this is in the form of a DID, the Issuer Service may
+  use the Identity Hub DID Service.  
+

--- a/specifications/M1/tx.dataspace.topology.md
+++ b/specifications/M1/tx.dataspace.topology.md
@@ -74,7 +74,7 @@ for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
 
 ### 2.2.3 DID Service (DIDS).
 
-The DCS Creates, signs and publishes DID documents.
+The DIDS Creates, signs and publishes DID documents.
 
 ## 2.3. Issuer Service (IS)
 

--- a/specifications/M1/tx.dataspace.topology.md
+++ b/specifications/M1/tx.dataspace.topology.md
@@ -67,9 +67,9 @@ represent an actual deployment topology.
 The STS creates self-issued authorization tokens that contain identity claims used by participant agents under the
 control of the same participant.
 
-### 2.2.2 Verifiable Credential Service (VCS)
+### 2.2.2 Credential Service (CS)
 
-The VCS manages [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/). This includes read and write endpoints
+The CS manages [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/). This includes read and write endpoints
 for Verifiable Presentations (VPs) and Verifiable Credentials (VCs).
 
 ### 2.2.3 DID Service (DIDS).


### PR DESCRIPTION
## Description

This PR is an initial commit of the _**Base Identity Protocol (BIP)**_ specification. It also contains a  **_Dataspace Topology_** document that defines key terms used by the _Identity Protocol_ specifications. 

The BIP defines how to obtain and communicate participant identities and claims using self-issued security tokens, namely: 

- A format for self-issued security tokens
- Endpoints and a flow to obtain self-issued security tokens

Subsequent specifications will define protocols for Verifiable Credential presentation and issuance.

Fixes #21 
