### PR TITLE
docs: add decision record about the usage of this repository

### DIFF
--- a/docs/decision-records/2023-07-17_usage_of_this_repository/README.md
+++ b/docs/decision-records/2023-07-17_usage_of_this_repository/README.md
@@ -1,0 +1,31 @@
+# Usage of this repository
+
+## Decision
+
+All documentation regarding specification and standards revolving around SSI and related topics should be hosted in this
+repository. No documentation regarding any particular implementation should be hosted there. Existing documents
+referring to implementation items will be deleted.
+
+Once concrete implementations exist, they will be linked in the SSI Docu repository.
+
+## Rationale
+
+In order to keep the scope of this repository focused on specifications and standards, it should not contain information
+or documentation about any particular implementation. This enables the technology-neutral definition of standards
+without mandating the use of any one specific implementation or even technology stack.
+
+To lower the barrier of entry for newcomers, we will list all known implementations of our standards in the landing page
+of the repo, or in another easily discoverable location.
+
+## Approach
+
+First, we will delete all documents related to concrete implementations from the repo, to create consistency. For all
+future contributions, the following process should be followed:
+
+- Every proposal starts out as a pull request from a personal fork of the repo
+- Pull requests should be small and focused
+- Authors can opt to create draft PR's, which may be advisable if the content of the PR is not yet final, and requires
+  further discussion.
+- Once the document has reached a final state, the PR should be converted to "Ready for Review" and reviews should be
+  requested, if not already done.
+- Reviewers are expected to complete their review within max 2 business days


### PR DESCRIPTION
## WHAT

Adds a decision record about how this repo is going to be used, and adds rudimentary information about the PR process. More information about this will come in a future PR.

## WHY

traceable decisions