### PR TITLE
chore: add metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,7 @@
+product: "ssi-docu"
+leadingRepository: "https://github.com/eclipse-tractusx/ssi-docu"
+repoCategory: "support"
+repositories:
+  - name: "ssi-docu"
+    usage: "This repository contains documentation about the Self-Sovereign Identity solution"
+    url: "https://github.com/eclipse-tractusx/ssi-docu"


### PR DESCRIPTION
PR to add .tractusx metadata file required as per https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5.